### PR TITLE
fix: harden CI permissions and auto-update demo SVGs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
@@ -13,7 +16,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies (Ubuntu)
         if: runner.os == 'Linux'
@@ -29,10 +32,40 @@ jobs:
       - name: Run tests (verbose)
         run: ./tests/run-tests.sh -v
 
+  demo-update:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y jq bc
+
+      - name: Regenerate demo SVGs
+        run: ./scripts/generate-demo.sh
+        env:
+          LANG: en_US.UTF-8
+          LC_ALL: en_US.UTF-8
+
+      - name: Commit updated SVGs (if changed)
+        run: |
+          git diff --quiet assets/ && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add assets/
+          git commit -m "chore: regenerate demo SVGs"
+          git push
+
   demo-freshness:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y jq bc
@@ -49,7 +82,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install ShellCheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck


### PR DESCRIPTION
## Summary

- Add explicit `permissions: contents: read` at workflow level (least privilege)
- Split `demo-freshness` into two jobs:
  - **`demo-update`** (PRs only) — regenerates SVGs and auto-commits if changed
  - **`demo-freshness`** (push to main) — gate check, fails if SVGs are stale
- Upgrade `actions/checkout` v4 → v6

## Security

Resolves CodeQL `actions/missing-workflow-permissions` — all jobs previously ran with default (overly broad) `GITHUB_TOKEN` permissions. Now explicitly scoped:

| Job | Permissions |
|-----|------------|
| test | `contents: read` (inherited) |
| demo-update | `contents: write` (needs to push SVG commits) |
| demo-freshness | `contents: read` (inherited) |
| shellcheck | `contents: read` (inherited) |

## Test plan

- [x] CI passes on this PR (test, shellcheck, demo-update)
- [x] `demo-update` job runs and completes (no SVG changes expected)
- [x] `demo-freshness` correctly skipped (PR event, not push)
- [ ] After merge: `demo-freshness` gate check works on push to main