### PR TITLE
fix: auto-configure settings.json and add NO_COLOR support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,12 @@ uninstall: ## Remove status line and caches
 	@echo "Removing status line..."
 	@rm -f ~/.claude/statusline.sh ~/.claude/cumulative-stats.sh
 	@rm -rf "$${XDG_CACHE_HOME:-$$HOME/.cache}/claude-code-statusline"
-	@echo "[ok] Files removed"
-	@echo ""
-	@echo "Deactivate in Claude Code:"
-	@echo "  claude config set --global statusline \"\""
+	@if [ -f ~/.claude/settings.json ] && command -v jq >/dev/null 2>&1; then \
+	  jq 'del(.statusLine)' ~/.claude/settings.json > ~/.claude/settings.json.tmp \
+	    && mv ~/.claude/settings.json.tmp ~/.claude/settings.json; \
+	  echo "[ok] Removed statusLine from settings.json"; \
+	fi
+	@echo "[ok] Uninstalled"
 
 test: ## Run test suite (54 assertions)
 	@./tests/run-tests.sh
@@ -40,7 +42,7 @@ verify: ## Smoke test installed statusline (run in a git repo)
 	@if [ ! -x ~/.claude/statusline.sh ]; then \
 	  echo "Not installed. Run: make install"; exit 1; \
 	fi
-	@echo '{"model":{"display_name":"Claude Opus 4.6"},"context_window":{"used_percentage":42,"total_input_tokens":5000,"total_output_tokens":1200},"cost":{"total_cost_usd":1.5,"total_duration_ms":120000,"total_api_duration_ms":80000},"workspace":{}}' \
+	@echo '{"model":{"id":"claude-opus-4-6","display_name":"Claude Opus 4.6"},"cwd":"/tmp","context_window":{"used_percentage":42,"context_window_size":200000,"total_input_tokens":5000,"total_output_tokens":1200},"cost":{"total_cost_usd":1.5,"total_duration_ms":120000,"total_api_duration_ms":80000},"workspace":{"project_dir":"/tmp","current_dir":"/tmp"}}' \
 	  | ~/.claude/statusline.sh
 	@echo ""
 	@echo "[ok] Status line is working"

--- a/README.md
+++ b/README.md
@@ -19,13 +19,7 @@ brew install jq                    # bc and git are pre-installed on macOS
 
 git clone https://github.com/ridjex/claude-code-statusline.git
 cd claude-code-statusline
-make install                       # checks deps, copies scripts to ~/.claude/
-```
-
-Then activate in Claude Code:
-
-```bash
-claude config set --global statusline "~/.claude/statusline.sh"
+make install                       # installs scripts + configures settings.json
 ```
 
 Verify it works (run inside any git repo):
@@ -34,11 +28,12 @@ Verify it works (run inside any git repo):
 make verify
 ```
 
+Then open a new Claude Code session.
+
 ## Uninstall
 
 ```bash
-make uninstall
-claude config set --global statusline ""
+make uninstall                     # removes scripts, caches, and settings.json entry
 ```
 
 ## Development
@@ -145,6 +140,15 @@ stdin JSON ──> statusline.sh ──> 2 formatted lines (stdout)
 - **macOS vs Linux** — uses `md5`/`stat -f` on macOS, `md5sum`/`stat -c` on Linux.
 - **Branch truncation** — names > 20 chars truncated with `…`.
 - **Worktree** — `⊕` prefix when working inside a git worktree.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Statusline blank | Set `export NO_COLOR=1` in your shell profile — works around a known Claude Code ANSI rendering bug |
+| Renders vertically | Widen terminal to > 120 columns; known Claude Code bug with narrow terminals ([#27849](https://github.com/anthropics/claude-code/issues/27849)) |
+| Not showing after install | Restart Claude Code session; verify with `make verify` |
+| Missing colors | Ensure terminal supports 256 colors (`echo $TERM` should show `xterm-256color` or similar) |
 
 ## Project structure
 

--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 # Claude Code Status Line — Installer
-# Copies scripts and creates cache directory.
+# Idempotent: safe to run on fresh install, upgrade, or to fix broken config.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEST_DIR="${HOME}/.claude"
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/claude-code-statusline"
+SETTINGS="$DEST_DIR/settings.json"
+SL_CONFIG='{"type":"command","command":"~/.claude/statusline.sh","padding":0}'
 
 echo "Claude Code Status Line — Installer"
 echo ""
@@ -28,27 +30,52 @@ echo "[ok] Dependencies: jq, bc, git"
 mkdir -p "$DEST_DIR" "$CACHE_DIR"
 echo "[ok] Directories ready"
 
-# Backup existing files
+# Backup and copy scripts (upgrade-safe)
 for f in statusline.sh cumulative-stats.sh; do
   if [ -f "$DEST_DIR/$f" ]; then
     cp "$DEST_DIR/$f" "$DEST_DIR/$f.bak"
-    echo "[ok] Backed up $f -> $f.bak"
   fi
 done
 
-# Copy scripts
 cp "$SCRIPT_DIR/src/statusline.sh" "$DEST_DIR/statusline.sh"
 cp "$SCRIPT_DIR/src/cumulative-stats.sh" "$DEST_DIR/cumulative-stats.sh"
 chmod +x "$DEST_DIR/statusline.sh" "$DEST_DIR/cumulative-stats.sh"
 echo "[ok] Scripts installed"
 
-echo ""
-echo "Installed:"
-echo "  $DEST_DIR/statusline.sh"
-echo "  $DEST_DIR/cumulative-stats.sh"
-echo "  $CACHE_DIR/"
+# Configure settings.json (handles all scenarios)
+if [ -f "$SETTINGS" ]; then
+  cp "$SETTINGS" "$SETTINGS.bak"
+
+  # Detect old string-based config from previous versions
+  # e.g. "statusLine": "~/.claude/statusline.sh" instead of proper object
+  OLD_TYPE=$(jq -r '.statusLine | type' "$SETTINGS" 2>/dev/null || echo "null")
+
+  if [ "$OLD_TYPE" = "string" ]; then
+    jq --argjson sl "$SL_CONFIG" '.statusLine = $sl' \
+      "$SETTINGS" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
+    echo "[ok] Fixed statusLine config (was string, now proper object)"
+  elif [ "$OLD_TYPE" = "object" ]; then
+    # Already an object — update to latest config
+    CURRENT=$(jq -c '.statusLine' "$SETTINGS" 2>/dev/null)
+    if [ "$CURRENT" = "$SL_CONFIG" ]; then
+      echo "[ok] settings.json already up to date"
+    else
+      jq --argjson sl "$SL_CONFIG" '.statusLine = $sl' \
+        "$SETTINGS" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
+      echo "[ok] Updated statusLine config"
+    fi
+  else
+    # No statusLine key yet — add it
+    jq --argjson sl "$SL_CONFIG" '.statusLine = $sl' \
+      "$SETTINGS" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
+    echo "[ok] Added statusLine to settings.json"
+  fi
+else
+  printf '{\"statusLine\":%s}\n' "$SL_CONFIG" | jq . > "$SETTINGS"
+  echo "[ok] Created $SETTINGS"
+fi
+
 echo ""
 echo "Next steps:"
-echo "  1. claude config set --global statusline \"~/.claude/statusline.sh\""
-echo "  2. make verify    # smoke test (run in any git repo)"
-echo "  3. Open a new Claude Code session"
+echo "  1. make verify    # smoke test (run in any git repo)"
+echo "  2. Open a new Claude Code session"

--- a/src/statusline.sh
+++ b/src/statusline.sh
@@ -26,6 +26,12 @@ for _dep in jq bc; do
   fi
 done
 
+# --- Color support (https://no-color.org/) ---
+_NO_COLOR=false
+if [ -n "${NO_COLOR:-}" ] || [ -n "${STATUSLINE_NO_COLOR:-}" ]; then
+  _NO_COLOR=true
+fi
+
 # --- Model ---
 MODEL=$(echo "$input" | jq -r '.model.display_name // "?"' | sed 's/^Claude //')
 
@@ -378,4 +384,11 @@ if [ -n "$CUM_ALL" ]; then
   L2="${L2} ${S} ${CUM_ALL}"
 fi
 
-printf "%b\n%b\n" "$L1" "$L2"
+if $_NO_COLOR; then
+  _strip_ansi() { sed 's/\x1b\[[0-9;]*m//g'; }
+  L1=$(printf "%b" "$L1" | _strip_ansi)
+  L2=$(printf "%b" "$L2" | _strip_ansi)
+  printf "%s\n%s\n" "$L1" "$L2"
+else
+  printf "%b\n%b\n" "$L1" "$L2"
+fi

--- a/tests/fixtures/basic-session.json
+++ b/tests/fixtures/basic-session.json
@@ -1,7 +1,14 @@
 {
-  "model": { "display_name": "Claude Opus 4.6" },
+  "cwd": "/tmp/statusline-test-project",
+  "session_id": "test-session-basic",
+  "model": {
+    "id": "claude-opus-4-6",
+    "display_name": "Claude Opus 4.6"
+  },
   "context_window": {
     "used_percentage": 38,
+    "remaining_percentage": 62,
+    "context_window_size": 200000,
     "total_input_tokens": 287500,
     "total_output_tokens": 41200
   },
@@ -12,5 +19,9 @@
     "total_lines_added": 127,
     "total_lines_removed": 34
   },
-  "workspace": { "project_dir": "/tmp/statusline-test-project" }
+  "version": "2.1.50",
+  "workspace": {
+    "project_dir": "/tmp/statusline-test-project",
+    "current_dir": "/tmp/statusline-test-project"
+  }
 }

--- a/tests/fixtures/cheap-session.json
+++ b/tests/fixtures/cheap-session.json
@@ -1,7 +1,14 @@
 {
-  "model": { "display_name": "Claude Haiku 4.5" },
+  "cwd": "/tmp/statusline-test-project",
+  "session_id": "test-session-cheap",
+  "model": {
+    "id": "claude-haiku-4-5",
+    "display_name": "Claude Haiku 4.5"
+  },
   "context_window": {
     "used_percentage": 5,
+    "remaining_percentage": 95,
+    "context_window_size": 200000,
     "total_input_tokens": 1200,
     "total_output_tokens": 340
   },
@@ -12,5 +19,9 @@
     "total_lines_added": 3,
     "total_lines_removed": 1
   },
-  "workspace": { "project_dir": "/tmp/statusline-test-project" }
+  "version": "2.1.50",
+  "workspace": {
+    "project_dir": "/tmp/statusline-test-project",
+    "current_dir": "/tmp/statusline-test-project"
+  }
 }

--- a/tests/fixtures/critical-context.json
+++ b/tests/fixtures/critical-context.json
@@ -1,7 +1,14 @@
 {
-  "model": { "display_name": "Claude Sonnet 4.5" },
+  "cwd": "/tmp/statusline-test-project",
+  "session_id": "test-session-critical",
+  "model": {
+    "id": "claude-sonnet-4-5",
+    "display_name": "Claude Sonnet 4.5"
+  },
   "context_window": {
     "used_percentage": 92,
+    "remaining_percentage": 8,
+    "context_window_size": 200000,
     "total_input_tokens": 700000,
     "total_output_tokens": 72000
   },
@@ -12,5 +19,9 @@
     "total_lines_added": 412,
     "total_lines_removed": 88
   },
-  "workspace": { "project_dir": "/tmp/statusline-test-project" }
+  "version": "2.1.50",
+  "workspace": {
+    "project_dir": "/tmp/statusline-test-project",
+    "current_dir": "/tmp/statusline-test-project"
+  }
 }

--- a/tests/fixtures/expensive-session.json
+++ b/tests/fixtures/expensive-session.json
@@ -1,7 +1,14 @@
 {
-  "model": { "display_name": "Claude Opus 4.6" },
+  "cwd": "/tmp/statusline-test-project",
+  "session_id": "test-session-expensive",
+  "model": {
+    "id": "claude-opus-4-6",
+    "display_name": "Claude Opus 4.6"
+  },
   "context_window": {
     "used_percentage": 65,
+    "remaining_percentage": 35,
+    "context_window_size": 200000,
     "total_input_tokens": 1250000,
     "total_output_tokens": 180000
   },
@@ -12,5 +19,9 @@
     "total_lines_added": 2340,
     "total_lines_removed": 890
   },
-  "workspace": { "project_dir": "/tmp/statusline-test-project" }
+  "version": "2.1.50",
+  "workspace": {
+    "project_dir": "/tmp/statusline-test-project",
+    "current_dir": "/tmp/statusline-test-project"
+  }
 }

--- a/tests/fixtures/high-context.json
+++ b/tests/fixtures/high-context.json
@@ -1,7 +1,14 @@
 {
-  "model": { "display_name": "Claude Opus 4.6" },
+  "cwd": "/tmp/statusline-test-project",
+  "session_id": "test-session-highctx",
+  "model": {
+    "id": "claude-opus-4-6",
+    "display_name": "Claude Opus 4.6"
+  },
   "context_window": {
     "used_percentage": 78,
+    "remaining_percentage": 22,
+    "context_window_size": 200000,
     "total_input_tokens": 500000,
     "total_output_tokens": 58000
   },
@@ -12,5 +19,9 @@
     "total_lines_added": 0,
     "total_lines_removed": 0
   },
-  "workspace": { "project_dir": "/tmp/statusline-test-project" }
+  "version": "2.1.50",
+  "workspace": {
+    "project_dir": "/tmp/statusline-test-project",
+    "current_dir": "/tmp/statusline-test-project"
+  }
 }

--- a/tests/fixtures/minimal.json
+++ b/tests/fixtures/minimal.json
@@ -1,7 +1,14 @@
 {
-  "model": { "display_name": "Claude Sonnet 4.5" },
+  "cwd": "/tmp",
+  "session_id": "test-session-minimal",
+  "model": {
+    "id": "claude-sonnet-4-5",
+    "display_name": "Claude Sonnet 4.5"
+  },
   "context_window": {
     "used_percentage": 1,
+    "remaining_percentage": 99,
+    "context_window_size": 200000,
     "total_input_tokens": 0,
     "total_output_tokens": 0
   },
@@ -10,5 +17,6 @@
     "total_duration_ms": 0,
     "total_api_duration_ms": 0
   },
+  "version": "2.1.50",
   "workspace": {}
 }

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -270,6 +270,34 @@ else
 fi
 
 # ============================================================
+echo "=== NO_COLOR mode ==="
+# ============================================================
+
+OUT_NC=$(NO_COLOR=1 render basic-session.json)
+$VERBOSE && echo "$OUT_NC" && echo ""
+
+# Should contain no ANSI escape codes
+if echo "$OUT_NC" | grep -q $'\x1b\['; then
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: NO_COLOR still contains ANSI codes"
+else
+  PASS=$((PASS + 1))
+fi
+assert_contains "NO_COLOR model name" "$OUT_NC" "Opus 4.6"
+assert_contains "NO_COLOR context" "$OUT_NC" "38%"
+assert_contains "NO_COLOR cost" "$OUT_NC" '$8.4'
+assert_line_count "NO_COLOR outputs 2 lines" "$OUT_NC" 2
+
+# STATUSLINE_NO_COLOR should also work
+OUT_SNC=$(STATUSLINE_NO_COLOR=1 render basic-session.json)
+if echo "$OUT_SNC" | grep -q $'\x1b\['; then
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: STATUSLINE_NO_COLOR still contains ANSI codes"
+else
+  PASS=$((PASS + 1))
+fi
+
+# ============================================================
 # Summary
 # ============================================================
 echo ""


### PR DESCRIPTION
## Summary

- **install.sh** now writes the proper JSON object `{"type":"command","command":"..."}` directly to `~/.claude/settings.json` instead of telling users to run `claude config set` (which wrote a plain string — root cause of statusline not appearing)
- Installer is fully idempotent: detects and auto-fixes string-based config from previous versions, handles fresh install / upgrade / repair without requiring uninstall first
- Added `NO_COLOR` / `STATUSLINE_NO_COLOR` env var support to work around Claude Code ANSI rendering bug ([#21066](https://github.com/anthropics/claude-code/issues/21066))
- Updated test fixtures with current Claude Code API fields (`cwd`, `model.id`, `context_window_size`, `version`, `workspace.current_dir`)
- 60 test assertions (was 54), all passing

## Test plan

- [x] `make test` — 60/60 pass
- [x] `make install` on existing correct config → "already up to date"
- [x] `make install` on string-based config → "Fixed statusLine config"
- [x] `make install` with no statusLine key → "Added statusLine to settings.json"
- [x] `make uninstall` → removes statusLine from settings.json, other keys preserved
- [x] `make verify` → renders with updated API payload
- [x] `NO_COLOR=1 make verify` → renders without ANSI codes