### PR TITLE
feat: configurable sections, skill, and diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,101 @@
+# Claude Code Status Line — Developer Guide
+
+## Project overview
+
+Pure-bash status bar for Claude Code. Zero external dependencies beyond jq, bc, git.
+Our differentiator vs competitors (ccstatusline, CCometixLine): no npm, no Rust, no Python — just bash.
+
+## Architecture
+
+```
+stdin JSON → statusline.sh → 1-2 lines stdout
+               ├── sources statusline.env (config)
+               ├── reads JSON caches (model stats, cumulative costs)
+               ├── reads git state
+               └── spawns background jobs (model parse, cost scan)
+```
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `src/statusline.sh` | Main renderer (~400 lines). Reads JSON from stdin, outputs formatted lines. |
+| `src/cumulative-stats.sh` | Background cost aggregator. Parses JSONL transcripts, caches per-project costs. |
+| `src/statusline.env.default` | Default config template. Copied to `~/.claude/statusline.env` on install. |
+| `install.sh` | Idempotent installer. Handles fresh/upgrade/repair scenarios. |
+| `skill/SKILL.md` | Claude Code skill for `/statusline` command. |
+| `tests/run-tests.sh` | Test runner. All assertions use `assert_contains` pattern. |
+| `tests/fixtures/` | Mock JSON payloads for each test scenario. |
+
+## Development
+
+```bash
+make test           # run all tests
+make test-verbose   # show rendered output
+make verify         # smoke test installed version
+make diagnose       # check installation health
+make demo           # regenerate SVG demos
+make check          # verify dependencies
+```
+
+## Conventions
+
+- **No `set -e`** in statusline.sh — must never crash Claude Code's render cycle
+- **POSIX-compatible bash** — no bashisms beyond arrays
+- **Errors are silent** — partial output is better than no output
+- **Sub-5ms render** — all heavy work in background jobs, hot path reads caches only
+- **Backward compatible** — new config options default to enabled
+- **Config via env vars** — sourced from `~/.claude/statusline.env`, all optional
+
+## Config system
+
+`~/.claude/statusline.env` is sourced at the top of statusline.sh. Variables:
+
+```bash
+STATUSLINE_SHOW_MODEL=true|false
+STATUSLINE_SHOW_MODEL_BARS=true|false
+STATUSLINE_SHOW_CONTEXT=true|false
+STATUSLINE_SHOW_COST=true|false
+STATUSLINE_SHOW_DURATION=true|false
+STATUSLINE_SHOW_GIT=true|false
+STATUSLINE_SHOW_DIFF=true|false
+STATUSLINE_LINE2=true|false
+STATUSLINE_SHOW_TOKENS=true|false
+STATUSLINE_SHOW_SPEED=true|false
+STATUSLINE_SHOW_CUMULATIVE=true|false
+```
+
+Helper function: `_show() { [ "${1:-true}" != "false" ]; }`
+
+## Adding a new section
+
+1. Add the data extraction inside a `_show` guard
+2. Add the variable to assembly block (Line 1 `_parts` array or Line 2 append)
+3. Add default to `src/statusline.env.default`
+4. Add test assertions in `tests/run-tests.sh`
+5. Update `skill/SKILL.md` config table
+
+## Testing
+
+- Use `render <fixture>` to run statusline.sh with test data
+- `assert_contains "label" "$OUT" "pattern"` — check output contains text
+- `assert_not_contains` — check output does NOT contain text
+- `strip_ansi` removes ANSI codes for comparison
+- Fixtures in `tests/fixtures/` — add new ones for new scenarios
+- Test config toggles by setting env vars: `STATUSLINE_SHOW_X=false render ...`
+
+## settings.json format
+
+The correct format in `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh",
+    "padding": 0
+  }
+}
+```
+
+**Never** set it as a plain string — that's the old bug format.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,18 @@ Tests use mock JSON fixtures in `tests/fixtures/`. No external services or Claud
 3. Run `make demo` — regenerate demo SVGs
 4. CI verifies SVGs are up to date (`demo-freshness` job)
 
+## Adding a config option
+
+1. Add `STATUSLINE_SHOW_X=true` to `src/statusline.env.default`
+2. Wrap section in `if _show "${STATUSLINE_SHOW_X:-}"; then ... fi`
+3. Add test: `STATUSLINE_SHOW_X=false render basic-session.json`
+4. Update `skill/SKILL.md` config table
+5. Update `README.md` Configuration section
+
 ## Code style
 
 - Shell scripts follow POSIX-compatible bash
 - No external dependencies beyond `jq`, `bc`, `git`
 - Keep render path fast (< 10ms) — expensive work goes in background jobs
+- Config via env vars sourced from `~/.claude/statusline.env`
+- No `set -e` in statusline.sh — must never crash Claude Code

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install uninstall test test-verbose demo check verify
+.PHONY: help install uninstall test test-verbose demo check verify diagnose
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
@@ -8,8 +8,9 @@ install: check ## Install status line to ~/.claude/
 
 uninstall: ## Remove status line and caches
 	@echo "Removing status line..."
-	@rm -f ~/.claude/statusline.sh ~/.claude/cumulative-stats.sh
+	@rm -f ~/.claude/statusline.sh ~/.claude/cumulative-stats.sh ~/.claude/statusline.env
 	@rm -rf "$${XDG_CACHE_HOME:-$$HOME/.cache}/claude-code-statusline"
+	@rm -rf ~/.claude/skills/statusline
 	@if [ -f ~/.claude/settings.json ] && command -v jq >/dev/null 2>&1; then \
 	  jq 'del(.statusLine)' ~/.claude/settings.json > ~/.claude/settings.json.tmp \
 	    && mv ~/.claude/settings.json.tmp ~/.claude/settings.json; \
@@ -37,6 +38,48 @@ check: ## Check dependencies (jq, bc, git)
 	  fi; \
 	done; \
 	$$ok || exit 1
+
+diagnose: ## Check installation health and config
+	@echo "=== Dependencies ==="
+	@for dep in jq bc git; do \
+	  if command -v $$dep >/dev/null 2>&1; then \
+	    printf "  [ok] %s\n" "$$dep"; \
+	  else \
+	    printf "  [!!] %s — missing\n" "$$dep"; \
+	  fi; \
+	done
+	@echo ""
+	@echo "=== Scripts ==="
+	@[ -x ~/.claude/statusline.sh ] && echo "  [ok] statusline.sh" || echo "  [!!] statusline.sh — missing or not executable"
+	@[ -x ~/.claude/cumulative-stats.sh ] && echo "  [ok] cumulative-stats.sh" || echo "  [!!] cumulative-stats.sh — missing or not executable"
+	@echo ""
+	@echo "=== settings.json ==="
+	@if [ -f ~/.claude/settings.json ]; then \
+	  TYPE=$$(jq -r '.statusLine | type' ~/.claude/settings.json 2>/dev/null); \
+	  if [ "$$TYPE" = "object" ]; then \
+	    CMD=$$(jq -r '.statusLine.command // "not set"' ~/.claude/settings.json); \
+	    echo "  [ok] statusLine type: object"; \
+	    echo "  [ok] statusLine command: $$CMD"; \
+	  elif [ "$$TYPE" = "string" ]; then \
+	    echo "  [!!] statusLine is a STRING (run: make install to fix)"; \
+	  else \
+	    echo "  [!!] statusLine not configured (run: make install)"; \
+	  fi; \
+	else \
+	  echo "  [!!] settings.json not found (run: make install)"; \
+	fi
+	@echo ""
+	@echo "=== Config ==="
+	@if [ -f ~/.claude/statusline.env ]; then \
+	  echo "  [ok] statusline.env found"; \
+	  grep -c "=false" ~/.claude/statusline.env | xargs -I{} echo "  [i ] {} sections disabled"; \
+	else \
+	  echo "  [i ] statusline.env not found (all defaults active)"; \
+	fi
+	@echo ""
+	@echo "=== Render test ==="
+	@echo '{"model":{"display_name":"Claude Opus 4.6"},"context_window":{"used_percentage":42,"total_input_tokens":5000,"total_output_tokens":1200},"cost":{"total_cost_usd":1.5,"total_duration_ms":120000,"total_api_duration_ms":80000},"workspace":{"project_dir":"/tmp","current_dir":"/tmp"}}' \
+	  | ~/.claude/statusline.sh 2>/dev/null && echo "  [ok] Render successful" || echo "  [!!] Render FAILED"
 
 verify: ## Smoke test installed statusline (run in a git repo)
 	@if [ ! -x ~/.claude/statusline.sh ]; then \

--- a/README.md
+++ b/README.md
@@ -36,14 +36,35 @@ Then open a new Claude Code session.
 make uninstall                     # removes scripts, caches, and settings.json entry
 ```
 
+## Configuration
+
+Edit `~/.claude/statusline.env` to toggle sections (created by `make install`):
+
+```bash
+STATUSLINE_SHOW_MODEL=true        # Model name
+STATUSLINE_SHOW_MODEL_BARS=true   # Mini bars (█▅▃)
+STATUSLINE_SHOW_CONTEXT=true      # Context window bar
+STATUSLINE_SHOW_COST=true         # Session cost
+STATUSLINE_SHOW_DURATION=true     # Wall clock time
+STATUSLINE_SHOW_GIT=true          # Branch + dirty
+STATUSLINE_SHOW_DIFF=true         # Lines +/-
+STATUSLINE_LINE2=true             # Show Line 2
+STATUSLINE_SHOW_TOKENS=true       # Token counts
+STATUSLINE_SHOW_SPEED=true        # tok/s throughput
+STATUSLINE_SHOW_CUMULATIVE=true   # ⌂/Σ cost tracking
+```
+
+Set any value to `false` to hide that section. Changes apply on next render (no restart needed).
+
 ## Development
 
 ```bash
 make                  # show all targets
-make test             # 54 assertions
+make test             # run test suite
 make test-verbose     # shows rendered output for each scenario
 make demo             # regenerate demo SVGs
 make check            # verify dependencies
+make diagnose         # check installation health
 ```
 
 ## Line 1
@@ -154,18 +175,22 @@ stdin JSON ──> statusline.sh ──> 2 formatted lines (stdout)
 
 ```
 claude-code-statusline/
-  Makefile                 # all commands: make help
-  install.sh               # installer (called by make install)
+  CLAUDE.md                 # project knowledge for Claude Code
+  Makefile                  # all commands: make help
+  install.sh                # idempotent installer
   src/
-    statusline.sh           # main renderer
-    cumulative-stats.sh     # background cost aggregator
+    statusline.sh            # main renderer
+    cumulative-stats.sh      # background cost aggregator
+    statusline.env.default   # default config template
+  skill/
+    SKILL.md                 # Claude Code /statusline skill
   tests/
-    run-tests.sh            # test runner (54 assertions)
-    fixtures/               # mock JSON data for all scenarios
+    run-tests.sh             # test runner
+    fixtures/                # mock JSON data for all scenarios
   scripts/
-    generate-demo.sh        # runs statusline.sh with fixtures → ANSI
-    ansi2svg.py             # converts ANSI output → SVG (dark + light)
+    generate-demo.sh         # runs statusline.sh with fixtures → ANSI
+    ansi2svg.py              # converts ANSI output → SVG (dark + light)
   assets/
-    demo-dark.svg           # auto-generated, verified in CI
-    demo-light.svg          # auto-generated, verified in CI
+    demo-dark.svg            # auto-generated, verified in CI
+    demo-light.svg           # auto-generated, verified in CI
 ```

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,15 @@ cp "$SCRIPT_DIR/src/cumulative-stats.sh" "$DEST_DIR/cumulative-stats.sh"
 chmod +x "$DEST_DIR/statusline.sh" "$DEST_DIR/cumulative-stats.sh"
 echo "[ok] Scripts installed"
 
+# Copy default config (only if user doesn't have one)
+SL_ENV="$DEST_DIR/statusline.env"
+if [ ! -f "$SL_ENV" ]; then
+  cp "$SCRIPT_DIR/src/statusline.env.default" "$SL_ENV"
+  echo "[ok] Created $SL_ENV (edit to customize sections)"
+else
+  echo "[ok] Existing $SL_ENV preserved"
+fi
+
 # Configure settings.json (handles all scenarios)
 if [ -f "$SETTINGS" ]; then
   cp "$SETTINGS" "$SETTINGS.bak"
@@ -73,6 +82,14 @@ if [ -f "$SETTINGS" ]; then
 else
   printf '{\"statusLine\":%s}\n' "$SL_CONFIG" | jq . > "$SETTINGS"
   echo "[ok] Created $SETTINGS"
+fi
+
+# Install Claude Code skill (for /statusline command)
+SKILL_DIR="$DEST_DIR/skills/statusline"
+if [ -f "$SCRIPT_DIR/skill/SKILL.md" ]; then
+  mkdir -p "$SKILL_DIR"
+  cp "$SCRIPT_DIR/skill/SKILL.md" "$SKILL_DIR/SKILL.md"
+  echo "[ok] Skill installed (/statusline command available)"
 fi
 
 echo ""

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: statusline
+description: Manage Claude Code status line — install, configure sections, diagnose issues, and customize display. Use when asked to "install statusline", "configure status line", "fix statusline", "hide sections", "show only cost", "statusline not working", "diagnose statusline", or any status line management task.
+metadata:
+  user-invocable: true
+---
+
+# Claude Code Status Line Manager
+
+Lightweight, zero-dep status bar for Claude Code (pure bash, jq/bc/git only).
+
+## Quick Reference
+
+| File | Purpose |
+|------|---------|
+| `~/.claude/statusline.sh` | Main renderer |
+| `~/.claude/cumulative-stats.sh` | Background cost aggregator |
+| `~/.claude/statusline.env` | Section config (all defaults to enabled) |
+| `~/.claude/settings.json` | Claude Code config (statusLine key) |
+| `~/.cache/claude-code-statusline/` | Token & cost caches |
+
+## Install / Update
+
+If the tool is already cloned:
+
+```bash
+cd <path-to-clone>/claude-code-statusline
+git pull
+make install
+```
+
+If not cloned yet:
+
+```bash
+brew install jq   # bc and git are pre-installed on macOS
+git clone https://github.com/ridjex/claude-code-statusline.git
+cd claude-code-statusline
+make install
+```
+
+The installer is idempotent — safe to run repeatedly. It:
+- Copies scripts to `~/.claude/`
+- Creates `~/.claude/statusline.env` with defaults (preserves existing)
+- Writes proper JSON object to `~/.claude/settings.json`
+- Auto-fixes old string-based config from `claude config set`
+
+## Uninstall
+
+```bash
+make uninstall
+```
+
+Removes scripts, caches, statusline.env, and the `statusLine` key from settings.json.
+
+## Configure Sections
+
+Edit `~/.claude/statusline.env`. Set any value to `false` to hide that section:
+
+```bash
+# Line 1
+STATUSLINE_SHOW_MODEL=true        # Model name (Opus 4.6)
+STATUSLINE_SHOW_MODEL_BARS=true   # Mini bars (█▅▃)
+STATUSLINE_SHOW_CONTEXT=true      # Context window bar
+STATUSLINE_SHOW_COST=true         # Session cost ($8.4)
+STATUSLINE_SHOW_DURATION=true     # Wall clock (15m)
+STATUSLINE_SHOW_GIT=true          # Branch + dirty/ahead/behind
+STATUSLINE_SHOW_DIFF=true         # Lines added/removed
+
+# Line 2
+STATUSLINE_LINE2=true             # Show Line 2 at all
+STATUSLINE_SHOW_TOKENS=true       # Per-model token counts
+STATUSLINE_SHOW_SPEED=true        # Output throughput (tok/s)
+STATUSLINE_SHOW_CUMULATIVE=true   # Project + all cost (⌂ Σ)
+```
+
+Changes take effect on the next Claude Code render cycle (no restart needed).
+
+### Common presets
+
+**Minimal (cost-only):**
+```bash
+STATUSLINE_SHOW_MODEL=false
+STATUSLINE_SHOW_MODEL_BARS=false
+STATUSLINE_SHOW_CONTEXT=false
+STATUSLINE_SHOW_DURATION=false
+STATUSLINE_SHOW_GIT=false
+STATUSLINE_SHOW_DIFF=false
+STATUSLINE_LINE2=false
+```
+
+**No cumulative (reduce clutter):**
+```bash
+STATUSLINE_SHOW_CUMULATIVE=false
+```
+
+**Single line:**
+```bash
+STATUSLINE_LINE2=false
+```
+
+## Diagnose Issues
+
+Run diagnostic check:
+
+```bash
+make diagnose
+```
+
+This checks:
+- Dependencies (jq, bc, git)
+- Script files exist and are executable
+- `settings.json` has proper JSON object format (not string)
+- `statusline.env` presence and disabled sections count
+- Live render test with sample JSON
+
+### Common problems
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Statusline blank | ANSI rendering bug in Claude Code | `export NO_COLOR=1` in shell profile |
+| Renders vertically | Narrow terminal + Claude Code bug | Widen to >120 columns |
+| Not showing after install | settings.json has string instead of object | `make install` (auto-fixes) |
+| Not showing at all | Missing statusLine in settings.json | `make install` |
+| Old data / wrong costs | Stale caches | `rm -rf ~/.cache/claude-code-statusline/` |
+
+### Manual fix for settings.json
+
+If `make diagnose` shows `statusLine is a STRING`:
+
+```bash
+# The installer fixes this automatically:
+make install
+
+# Or manual fix via jq:
+jq '.statusLine = {"type":"command","command":"~/.claude/statusline.sh","padding":0}' \
+  ~/.claude/settings.json > /tmp/s.json && mv /tmp/s.json ~/.claude/settings.json
+```
+
+## Add Skill to a Project
+
+To make this skill available in a specific project, create `.claude/skills/statusline/SKILL.md` in that project and copy this file's content. Or symlink:
+
+```bash
+mkdir -p .claude/skills/statusline
+ln -s ~/.claude/skills/statusline/SKILL.md .claude/skills/statusline/SKILL.md
+```
+
+## Architecture
+
+```
+stdin JSON ──> statusline.sh ──> 1-2 formatted lines (stdout)
+                  │
+                  ├── sources ~/.claude/statusline.env (if exists)
+                  ├── reads cached model stats (models-{session}.json)
+                  ├── reads cached cumulative costs (proj-*.json, all.json)
+                  ├── reads git state (branch, dirty, ahead/behind)
+                  │
+                  └── spawns 2 background jobs (non-blocking):
+                        ├── parse transcript → update model cache
+                        └── cumulative-stats.sh → update cost caches
+```
+
+Performance: ~5ms render (reads JSON caches, no parsing in hot path).

--- a/src/statusline.env.default
+++ b/src/statusline.env.default
@@ -1,0 +1,19 @@
+# Claude Code Status Line — Configuration
+# Copy to ~/.claude/statusline.env and edit to customize.
+# All values default to true when this file is absent.
+# Set any value to "false" to disable that section.
+
+# ── Line 1 sections ──
+STATUSLINE_SHOW_MODEL=true        # Model name (e.g. "Opus 4.6")
+STATUSLINE_SHOW_MODEL_BARS=true   # Mini bars showing model mix (█▅▃)
+STATUSLINE_SHOW_CONTEXT=true      # Context window bar + percentage
+STATUSLINE_SHOW_COST=true         # Session cost ($8.4)
+STATUSLINE_SHOW_DURATION=true     # Wall clock time (15m)
+STATUSLINE_SHOW_GIT=true          # Branch, dirty indicator, ahead/behind
+STATUSLINE_SHOW_DIFF=true         # Lines added/removed (+127 -34)
+
+# ── Line 2 sections ──
+STATUSLINE_LINE2=true             # Show Line 2 at all
+STATUSLINE_SHOW_TOKENS=true       # Per-model or total token counts
+STATUSLINE_SHOW_SPEED=true        # Output throughput (tok/s)
+STATUSLINE_SHOW_CUMULATIVE=true   # Project + all-projects cost (⌂ Σ)

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -270,6 +270,49 @@ else
 fi
 
 # ============================================================
+echo "=== Section toggles ==="
+# ============================================================
+
+# LINE2=false → only 1 line output
+OUT_L1=$(STATUSLINE_LINE2=false render basic-session.json)
+$VERBOSE && echo "$OUT_L1" && echo ""
+assert_contains "L2 off still has model" "$OUT_L1" "Opus 4.6"
+assert_not_contains "L2 off no tok/s" "$OUT_L1" "tok/s"
+
+# Hide git
+OUT_NOGIT=$(STATUSLINE_SHOW_GIT=false render basic-session.json)
+assert_not_contains "no git branch" "$OUT_NOGIT" "main"
+
+# Hide cost
+OUT_NOCOST=$(STATUSLINE_SHOW_COST=false render basic-session.json)
+assert_not_contains "no cost" "$OUT_NOCOST" '$8.4'
+
+# Hide duration
+OUT_NODUR=$(STATUSLINE_SHOW_DURATION=false render basic-session.json)
+assert_not_contains "no duration" "$OUT_NODUR" "15m"
+
+# Hide context
+OUT_NOCTX=$(STATUSLINE_SHOW_CONTEXT=false render basic-session.json)
+assert_not_contains "no context bar" "$OUT_NOCTX" "38%"
+
+# Hide diff
+OUT_NODIFF=$(STATUSLINE_SHOW_DIFF=false render basic-session.json)
+assert_not_contains "no diff added" "$OUT_NODIFF" "+127"
+
+# Hide speed
+OUT_NOSPD=$(STATUSLINE_SHOW_SPEED=false render basic-session.json)
+assert_not_contains "no speed" "$OUT_NOSPD" "tok/s"
+
+# Hide cumulative
+cp "$FIXTURES/cumulative-proj.json" "$TEST_CACHE/claude-code-statusline/proj-${_HASH}.json"
+cp "$FIXTURES/cumulative-all.json" "$TEST_CACHE/claude-code-statusline/all.json"
+OUT_NOCUM=$(STATUSLINE_SHOW_CUMULATIVE=false render basic-session.json)
+assert_not_contains "no cumulative proj" "$OUT_NOCUM" "⌂"
+assert_not_contains "no cumulative all" "$OUT_NOCUM" "Σ"
+rm -f "$TEST_CACHE/claude-code-statusline/proj-${_HASH}.json"
+rm -f "$TEST_CACHE/claude-code-statusline/all.json"
+
+# ============================================================
 echo "=== NO_COLOR mode ==="
 # ============================================================
 


### PR DESCRIPTION
## Summary

- **Configurable sections** via `~/.claude/statusline.env` — toggle any section on/off (all default to enabled for backward compat)
- **Claude Code skill** (`/statusline`) — install, configure, diagnose, and troubleshoot from Claude Code
- **`make diagnose`** — full health check (deps, scripts, settings.json format, config, render test)
- **Improved installer** — copies default config, installs skill, preserves existing statusline.env on upgrade
- **CLAUDE.md** — project knowledge for contributors and Claude Code

## Config options

```bash
# Line 1
STATUSLINE_SHOW_MODEL=true
STATUSLINE_SHOW_MODEL_BARS=true
STATUSLINE_SHOW_CONTEXT=true
STATUSLINE_SHOW_COST=true
STATUSLINE_SHOW_DURATION=true
STATUSLINE_SHOW_GIT=true
STATUSLINE_SHOW_DIFF=true

# Line 2
STATUSLINE_LINE2=true
STATUSLINE_SHOW_TOKENS=true
STATUSLINE_SHOW_SPEED=true
STATUSLINE_SHOW_CUMULATIVE=true
```

## Test plan

- [x] `make test` — 70/70 pass (was 60)
- [x] All section toggles verified (git off, cost off, Line 2 off, cumulative off, etc.)
- [x] `make install` on clean machine — creates config + skill
- [x] `make install` on existing config — preserves user settings
- [x] `make diagnose` — full health check output
- [x] `make uninstall` — cleans config, skill, and settings.json
- [x] Backward compatible — no config file = all sections enabled

Closes #4, closes #5, closes #6, closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)